### PR TITLE
Fix peer dependencies range

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "styled-components": "^1.3.1"
   },
   "peerDependencies": {
-    "react": "15.x",
-    "styled-components": "^1.3.1"
+    "styled-components": "^1.3.1 || ^2.0.0"
   }
 }


### PR DESCRIPTION
Fix for styled-components 2.0 and upcoming React 16 (actually just removed react as it is not a peer dependency of this module)